### PR TITLE
Fix UTF-8 Shapefiles

### DIFF
--- a/backend/export_request_processor.pl
+++ b/backend/export_request_processor.pl
@@ -128,7 +128,7 @@ if (my $run = $sth_fetch->fetchrow_hashref)
 
     # call ogr2ogr to make shape files in temporary directory
     mkdir "/tmp/$rid-shp";
-    mysystem("ogr2ogr -overwrite -f 'ESRI Shapefile' --config SHAPE_ENCODING UTF-8 /tmp/$rid-shp $OUTPUT_PATH/$rid/$name.sqlite");
+    mysystem("ogr2ogr -overwrite -f 'ESRI Shapefile' /tmp/$rid-shp $OUTPUT_PATH/$rid/$name.sqlite -lco ENCODING=UTF-8");
 
     # load ogr2ogr output to find out field name truncations
     my $crosswalk = {};


### PR DESCRIPTION
An export of Syrian Admin Boundaries to Shapefile currently corrupts all the Arabic names.
If I use gdal 1.10 locally on Win32 then the syntax in the Pull Request works fine: Shapefile has Arabic names in properly.
