### PR TITLE
Update export_request_processor.pl - fixing prj bug

### DIFF
--- a/backend/export_request_processor.pl
+++ b/backend/export_request_processor.pl
@@ -163,7 +163,7 @@ if (my $run = $sth_fetch->fetchrow_hashref)
     foreach my $prj(glob("/tmp/$rid-shp/*.prj"))
     {
         open(PRJ, ">$prj");
-        print PRJ 'PROJCS["WGS 84 / Pseudo-Mercator",GEOGCS["Popular Visualisation CRS",DATUM["Popular_Visualisation_Datum",SPHEROID["Popular Visualisation Sphere",6378137,0,AUTHORITY["EPSG","7059"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6055"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4055"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Mercator_1SP"],PARAMETER["central_meridian",0],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","3785"],AXIS["X",EAST],AXIS["Y",NORTH]]';
+        print PRJ 'PROJCS["WGS_84_Pseudo_Mercator",GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137,298.257223563]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Mercator"],PARAMETER["central_meridian",0],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["Meter",1],PARAMETER["standard_parallel_1",0.0]]';
         close(PRJ);
         $prj =~ /(.*)\.prj$/;
         my $cpg = $1.'.cpg';


### PR DESCRIPTION
Changed deprecated EPSG:3785 PRJ non recognized by ArcGIS by EPSG:3857 tested on ArcGIS. Should solve https://github.com/hotosm/hot-exports/issues/94, https://github.com/hotosm/hot-exports/issues/80, https://github.com/hotosm/hot-exports/issues/76 and
https://github.com/hotosm/hot-exports/issues/75